### PR TITLE
global ontoscore button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@italia/dati-semantic-schema-editor",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "main": "index.js",
   "keywords": [],

--- a/packages/schema-editor/src/plugins/json-schema-5/components/global-onto-score-button.spec.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/global-onto-score-button.spec.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as configuration from '../../configuration';
+import * as utils from '../utils';
+import { GlobalOntoScoreButton } from './global-onto-score-button';
+
+describe('GlobalOntoScoreButton', () => {
+  beforeEach(() => {
+    vi.spyOn(configuration, 'useConfiguration').mockReturnValue({
+      sparqlUrl: 'https://test-sparql-url.com',
+    });
+  });
+
+  it('should render', async () => {
+    const mockSpecSelectors = getMockSpecSelectors();
+    render(<GlobalOntoScoreButton specSelectors={mockSpecSelectors} />);
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  it('should render button with initial state', () => {
+    const button = screen.getByRole('button');
+    expect(button).toBeTruthy();
+    expect(button.innerHTML).toContain('Global OntoScore β: 0.00');
+    expect(button.classList).toContain('btn-secondary'); // Not calculated initially
+  });
+
+  it('should calculate global ontoscore on click', async () => {
+    const calculateGlobalOntoscoreSpy = vi
+      .spyOn(utils, 'calculateGlobalOntoscore')
+      .mockResolvedValueOnce({ resolvedSpecJson: {}, globalOntoScore: 0.5 });
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(calculateGlobalOntoscoreSpy).toHaveBeenCalled();
+      expect(button.innerHTML).toContain('Global OntoScore β: 0.50');
+      expect(button.classList).toContain('btn-success'); // Just calculated
+    });
+  });
+});
+
+const getMockSpecSelectors = () => {
+  return {
+    specJson: () => ({
+      toJS: () => ({}),
+    }),
+  };
+};

--- a/packages/schema-editor/src/plugins/json-schema-5/components/global-onto-score-button.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/global-onto-score-button.tsx
@@ -1,0 +1,46 @@
+import { Button, Spinner } from 'design-react-kit';
+import { useCallback, useMemo, useState } from 'react';
+import { useConfiguration } from '../../configuration';
+import { calculateGlobalOntoscore, to32CharString } from '../utils';
+
+export const GlobalOntoScoreButton = ({ specSelectors }) => {
+  const { sparqlUrl = '' } = useConfiguration();
+
+  const [ontoscore, setOntoscore] = useState<number>(0);
+  const [lastHash, setLastHash] = useState<string | null>(null);
+  const [isLoading, setLoading] = useState(false);
+
+  const specJson = useMemo(() => specSelectors.specJson().toJS(), [specSelectors.specJson().toJS()]);
+  const currentHash = useMemo(() => to32CharString(JSON.stringify(specJson)), [specJson]);
+
+  const recalculate = useCallback(async () => {
+    try {
+      setLoading(true);
+
+      // Calculate global ontoscore
+      const { globalOntoScore } = await calculateGlobalOntoscore(specJson, { sparqlUrl });
+      setOntoscore(globalOntoScore);
+
+      // Update hash to give a feedback to the user
+      const hash = to32CharString(JSON.stringify(specJson));
+      setLastHash(hash);
+    } finally {
+      setLoading(false);
+    }
+  }, [specJson, sparqlUrl]);
+
+  const isUpdated = lastHash && currentHash && lastHash === currentHash;
+
+  return (
+    <Button
+      color={isUpdated ? 'success' : 'secondary'}
+      size="xs"
+      onClick={recalculate}
+      disabled={isLoading}
+      title={isUpdated ? 'Global OntoScore is up to date' : 'Global OntoScore is outdated, click to recalculate'}
+    >
+      {isLoading && <Spinner active small className="me-2" />}
+      <span>Global OntoScore β: {ontoscore !== null ? ontoscore.toFixed(2) : '-'}</span>
+    </Button>
+  );
+};

--- a/packages/schema-editor/src/plugins/json-schema-5/components/models.tsx
+++ b/packages/schema-editor/src/plugins/json-schema-5/components/models.tsx
@@ -2,6 +2,7 @@ import './models.scss';
 
 import { useSchemaNavigation } from '../../overview/components/Navigation';
 import { ActionsMenu } from './actions-menu';
+import { GlobalOntoScoreButton } from './global-onto-score-button';
 import { ModelCollapseRoot } from './model-collapse-root';
 import type { ModelRoot as ModelRootComponent } from './model-root';
 import type { ModelsBreadcrumb as ModelsBreadcrumbComponent } from './models-breadcrumb';
@@ -24,9 +25,13 @@ export function Models({ getComponent, specSelectors, getConfigs, specActions })
 
   return (
     <div className="modelli">
-      <div className="d-flex flex-row justify-content-between">
+      <div className="d-flex flex-row justify-content-between align-items-center">
         <ModelsBreadcrumb specPathBase={specPathBase} />
         <ActionsMenu specSelectors={specSelectors} url={url} specActions={specActions} />
+      </div>
+
+      <div className="d-flex flex-row justify-content-end align-items-center mb-2">
+        <GlobalOntoScoreButton specSelectors={specSelectors} />
       </div>
 
       {/* Root */}


### PR DESCRIPTION
Fixes #24 
Added a global ontoscore button that calculates the ontoscore for the whole spec.
It shows a gray background if not synced, otherwise a green one.
Moved existing method from actions-manu to the onto-score functions file.